### PR TITLE
ipfs service refactored and added to MurmurClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,19 @@
       "version": "0.1.0",
       "dependencies": {
         "@headlessui/react": "^2.0.4",
+        "@helia/dag-cbor": "^3.0.6",
+        "@helia/dag-json": "^3.0.6",
         "@heroicons/react": "^2.1.3",
         "@ideallabs/etf.js": "0.1.11-dev",
+        "@libp2p/bootstrap": "^10.1.5",
+        "@libp2p/circuit-relay-v2": "^1.0.4",
+        "@libp2p/dcutr": "^1.0.3",
+        "@libp2p/identify": "^2.1.0",
+        "@libp2p/mplex": "^10.1.0",
+        "@libp2p/pubsub-peer-discovery": "^10.0.2",
+        "@libp2p/webrtc": "^4.0.5",
+        "@libp2p/websockets": "^9.0.1",
+        "@libp2p/webtransport": "^4.1.8",
         "@polkadot/api": "^12.2.3",
         "@polkadot/api-contract": "^12.2.3",
         "@polkadot/extension-dapp": "^0.50.1",
@@ -18,6 +29,9 @@
         "@polkadot/util-crypto": "^13.0.2",
         "clsx": "^2.1.1",
         "framer-motion": "^11.2.6",
+        "helia": "^4.2.6",
+        "libp2p": "^2.0.2",
+        "multiformats": "^13.3.0",
         "next": "^14.2.5",
         "react": "^18",
         "react-dom": "^18",
@@ -38,6 +52,57 @@
         "prettier-plugin-tailwindcss": "^0.6.0",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@achingbrain/nat-port-mapper/-/nat-port-mapper-1.0.15.tgz",
+      "integrity": "sha512-jPXTuw88ogjo689QfKv5qsO2Y3Sv9mnPq6pH30LOU3bevevED/nMdFbAyrGbt3V3thsSvZGcGJ/lRSE7EE2jaw==",
+      "dependencies": {
+        "@achingbrain/ssdp": "^4.0.1",
+        "@libp2p/logger": "^5.0.1",
+        "default-gateway": "^7.2.2",
+        "err-code": "^3.0.1",
+        "it-first": "^3.0.1",
+        "p-defer": "^4.0.0",
+        "p-timeout": "^6.1.1",
+        "xml2js": "^0.6.0"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/@libp2p/interface": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.1.0.tgz",
+      "integrity": "sha512-22TD1KMP29xzlzYNH5zpi3E3WvshNC+MeYm1arD7PjLYvQLYKsm+HVaTVweLtqvuEVjMNNB4Q5JLNelM2tELgA==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.2.3",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^13.1.0",
+        "progress-events": "^1.0.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@achingbrain/nat-port-mapper/node_modules/@libp2p/logger": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-5.0.2.tgz",
+      "integrity": "sha512-sUE/clwUQQDiPxrtwmfVJjz8B1to713XziTvs9WqEdU6AkoOQV7S18aosvUw3+AjuBMpthYst1gewRkWivH7ag==",
+      "dependencies": {
+        "@libp2p/interface": "^2.1.0",
+        "@multiformats/multiaddr": "^12.2.3",
+        "interface-datastore": "^8.3.0",
+        "multiformats": "^13.1.0",
+        "weald": "^1.0.2"
+      }
+    },
+    "node_modules/@achingbrain/ssdp": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@achingbrain/ssdp/-/ssdp-4.0.6.tgz",
+      "integrity": "sha512-Y4JE2L9150i50V6lg/Y8+ilhxRpUZKKv+PKo68Aj7MjPfaUAar6ZHilF9h4/Zb3q0fqGMXNc9o11cQLNI8J8bA==",
+      "dependencies": {
+        "event-iterator": "^2.0.0",
+        "freeport-promise": "^2.0.0",
+        "merge-options": "^3.0.4",
+        "xml2js": "^0.6.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -62,6 +127,71 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@chainsafe/as-chacha20poly1305": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/as-chacha20poly1305/-/as-chacha20poly1305-0.1.0.tgz",
+      "integrity": "sha512-BpNcL8/lji/GM3+vZ/bgRWqJ1q5kwvTFmGPk7pxm/QQZDbaMI98waOHjEymTjq2JmdD/INdNBFOVSyJofXg7ew=="
+    },
+    "node_modules/@chainsafe/as-sha256": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.4.2.tgz",
+      "integrity": "sha512-HJ8GZBRjLeWtRsAXf3EbNsNzmTGpzTFjfpSf4yHkLYC+E52DhT6hwz+7qpj6I/EmFzSUm5tYYvT9K8GZokLQCQ=="
+    },
+    "node_modules/@chainsafe/is-ip": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.2.tgz",
+      "integrity": "sha512-ndGqEMG1W5WkGagaqOZHpPU172AGdxr+LD15sv3WIUvT5oCFUrG1Y0CW/v2Egwj4JXEvSibaIIIqImsm98y1nA=="
+    },
+    "node_modules/@chainsafe/libp2p-noise": {
+      "version": "15.1.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-15.1.2.tgz",
+      "integrity": "sha512-o6mqsAbaCBucgdLOOHtkwtGVL1c8RLKhlTnHQY+leazY+thiE1Sm6qPCwsTHKQnWii1q5hDVI2Q0l9QgYi5v4Q==",
+      "dependencies": {
+        "@chainsafe/as-chacha20poly1305": "^0.1.0",
+        "@chainsafe/as-sha256": "^0.4.1",
+        "@libp2p/crypto": "^4.0.0",
+        "@libp2p/interface": "^1.5.0",
+        "@libp2p/peer-id": "^4.0.0",
+        "@noble/ciphers": "^0.6.0",
+        "@noble/curves": "^1.1.0",
+        "@noble/hashes": "^1.3.1",
+        "it-length-prefixed": "^9.0.1",
+        "it-length-prefixed-stream": "^1.0.0",
+        "it-pair": "^2.0.6",
+        "it-pipe": "^3.0.1",
+        "it-stream-types": "^2.0.1",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^5.0.0",
+        "wherearewe": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-yamux": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-yamux/-/libp2p-yamux-6.0.2.tgz",
+      "integrity": "sha512-S5OkLHqYhEVMQQ4BTgnRANEIbGTQhaC23glCgBwGdeoTRtMpIozwDiPfljFLCm0RYWdCRJw9oFztO95KUHjptA==",
+      "dependencies": {
+        "@libp2p/interface": "^1.1.3",
+        "@libp2p/utils": "^5.2.5",
+        "get-iterator": "^2.0.1",
+        "it-foreach": "^2.0.6",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.2.3",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@chainsafe/netmask": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/netmask/-/netmask-2.0.0.tgz",
+      "integrity": "sha512-I3Z+6SWUoaljh3TBzCnCxjlUyN8tA+NAk5L6m9IxvCf1BENQTePzPMis97CoN/iMW1St3WN+AWCCRp+TTBRiDg==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -184,6 +314,167 @@
       "peerDependencies": {
         "react": "^18",
         "react-dom": "^18"
+      }
+    },
+    "node_modules/@helia/bitswap": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@helia/bitswap/-/bitswap-1.1.4.tgz",
+      "integrity": "sha512-BcmIc2FZ0NEjSYrwJxzFO5OapcOCBfcHmaBKaDoPNVh1egLLUkws2a7C3hPH5ZR7PXGQPXonH1YFz1CKYypzgA==",
+      "dependencies": {
+        "@helia/interface": "^4.3.1",
+        "@helia/utils": "^0.3.3",
+        "@libp2p/interface": "^1.1.4",
+        "@libp2p/logger": "^4.0.5",
+        "@libp2p/peer-collections": "^5.1.6",
+        "@libp2p/utils": "^5.2.3",
+        "@multiformats/multiaddr": "^12.1.14",
+        "any-signal": "^4.1.1",
+        "interface-blockstore": "^5.2.9",
+        "interface-store": "^5.1.7",
+        "it-drain": "^3.0.5",
+        "it-length-prefixed": "^9.0.0",
+        "it-length-prefixed-stream": "^1.1.6",
+        "it-map": "^3.0.5",
+        "it-pipe": "^3.0.1",
+        "it-take": "^3.0.1",
+        "multiformats": "^13.0.1",
+        "p-defer": "^4.0.0",
+        "progress-events": "^1.0.0",
+        "protons-runtime": "^5.0.0",
+        "race-event": "^1.2.0",
+        "uint8-varint": "^2.0.3",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/@helia/block-brokers": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@helia/block-brokers/-/block-brokers-3.0.4.tgz",
+      "integrity": "sha512-ymtV2cNrVeRoXsAOTpx558nDzfyOu87bLAewF98OVZ/NB28EUTy0c592GHLX3QcMaW/XfTzSGCi+te3fvVIuQg==",
+      "dependencies": {
+        "@helia/bitswap": "^1.1.4",
+        "@helia/interface": "^4.3.1",
+        "@helia/utils": "^0.3.3",
+        "@libp2p/interface": "^1.1.4",
+        "@libp2p/utils": "^5.2.6",
+        "@multiformats/multiaddr": "^12.2.1",
+        "@multiformats/multiaddr-matcher": "^1.2.0",
+        "@multiformats/multiaddr-to-uri": "^10.0.1",
+        "interface-blockstore": "^5.2.10",
+        "interface-store": "^5.1.8",
+        "multiformats": "^13.1.0",
+        "progress-events": "^1.0.0"
+      }
+    },
+    "node_modules/@helia/dag-cbor": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@helia/dag-cbor/-/dag-cbor-3.0.6.tgz",
+      "integrity": "sha512-oQKip7IMEStarPA4U6MSyynEZRoxFU6cvZbKcHruogPOBbuYqfj4IbTsD0dtd7qCZ/tvpR1air5T878CmbDDPA==",
+      "dependencies": {
+        "@helia/interface": "^4.3.1",
+        "@ipld/dag-cbor": "^9.2.0",
+        "@libp2p/interface": "^1.1.4",
+        "interface-blockstore": "^5.2.10",
+        "multiformats": "^13.1.0",
+        "progress-events": "^1.0.0"
+      }
+    },
+    "node_modules/@helia/dag-json": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@helia/dag-json/-/dag-json-3.0.6.tgz",
+      "integrity": "sha512-yDFhlGW7pclbm3tk9eRN3ddN9P7JVYAa4FDT8ZP3l3RyAPKjyKZQnxdiCyW2DvUp25YJn7j3Y01ty0k1coNa/A==",
+      "dependencies": {
+        "@helia/interface": "^4.3.1",
+        "@ipld/dag-json": "^10.2.0",
+        "@libp2p/interface": "^1.1.4",
+        "interface-blockstore": "^5.2.10",
+        "multiformats": "^13.1.0",
+        "progress-events": "^1.0.0"
+      }
+    },
+    "node_modules/@helia/delegated-routing-v1-http-api-client": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@helia/delegated-routing-v1-http-api-client/-/delegated-routing-v1-http-api-client-3.0.2.tgz",
+      "integrity": "sha512-BhyccWduikj+TOmGSBR++8hLmanvYZD4qoy1ZrXVXxVBFiGv9Lo+Tqa6cRZz0z8cQzs7CYT4yDpWo5odphrhkQ==",
+      "dependencies": {
+        "@libp2p/interface": "^1.1.1",
+        "@libp2p/logger": "^4.0.4",
+        "@libp2p/peer-id": "^4.0.4",
+        "@multiformats/multiaddr": "^12.1.3",
+        "any-signal": "^4.1.1",
+        "browser-readablestream-to-it": "^2.0.3",
+        "ipns": "^9.0.0",
+        "it-first": "^3.0.3",
+        "it-map": "^3.0.4",
+        "it-ndjson": "^1.0.4",
+        "multiformats": "^13.0.0",
+        "p-defer": "^4.0.0",
+        "p-queue": "^8.0.1",
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/@helia/interface": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@helia/interface/-/interface-4.3.1.tgz",
+      "integrity": "sha512-jvuUUAQbLMhvMt+Lon7mJfJt5xJWiwn8aXtI9fHBpMNMsrKJOtefxAzwSr18xe+C9bMdOyRtocj2eFhs74bQ8w==",
+      "dependencies": {
+        "@libp2p/interface": "^1.1.4",
+        "@multiformats/dns": "^1.0.1",
+        "interface-blockstore": "^5.2.10",
+        "interface-datastore": "^8.2.11",
+        "interface-store": "^5.1.8",
+        "multiformats": "^13.1.0",
+        "progress-events": "^1.0.0"
+      }
+    },
+    "node_modules/@helia/routers": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@helia/routers/-/routers-1.1.1.tgz",
+      "integrity": "sha512-LsEkUAno4PiQ1cmwxFnYWy5xQicpzjXyYeRJEGLjAnAXin8hq0JPkEouZx8vTlmSf1Rde4RSaTu3+3H1qj5ccw==",
+      "dependencies": {
+        "@helia/delegated-routing-v1-http-api-client": "^3.0.0",
+        "@helia/interface": "^4.3.1",
+        "@libp2p/interface": "^1.1.4",
+        "@multiformats/uri-to-multiaddr": "^8.0.0",
+        "ipns": "^9.0.0",
+        "it-first": "^3.0.4",
+        "it-map": "^3.0.5",
+        "multiformats": "^13.1.0",
+        "uint8arrays": "^5.0.2"
+      }
+    },
+    "node_modules/@helia/utils": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@helia/utils/-/utils-0.3.3.tgz",
+      "integrity": "sha512-iCS8dJRULgltfx7aLLoqfjWUpqBWrTyouCToB9RgHpNs4lHcIsZn/VSbHyjC4NUF9nIWsxhH/3UAdvWl23HEgw==",
+      "dependencies": {
+        "@helia/interface": "^4.3.1",
+        "@ipld/dag-cbor": "^9.2.0",
+        "@ipld/dag-json": "^10.2.0",
+        "@ipld/dag-pb": "^4.1.0",
+        "@libp2p/crypto": "^4.0.6",
+        "@libp2p/interface": "^1.1.4",
+        "@libp2p/logger": "^4.0.7",
+        "@libp2p/utils": "^5.2.6",
+        "@multiformats/dns": "^1.0.1",
+        "@types/murmurhash3js-revisited": "^3.0.3",
+        "any-signal": "^4.1.1",
+        "blockstore-core": "^4.4.1",
+        "cborg": "^4.0.9",
+        "interface-blockstore": "^5.2.10",
+        "interface-datastore": "^8.2.11",
+        "interface-store": "^5.1.8",
+        "it-drain": "^3.0.5",
+        "it-filter": "^3.0.4",
+        "it-foreach": "^2.0.6",
+        "it-merge": "^3.0.3",
+        "mortice": "^3.0.4",
+        "multiformats": "^13.1.0",
+        "murmurhash3js-revisited": "^3.0.0",
+        "p-defer": "^4.0.1",
+        "progress-events": "^1.0.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.0.2"
       }
     },
     "node_modules/@heroicons/react": {
@@ -852,6 +1143,44 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@ipld/dag-cbor": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.1.tgz",
+      "integrity": "sha512-nyY48yE7r3dnJVlxrdaimrbloh4RokQaNRdI//btfTkcTEZbpmSrbYcBQ4VKTf8ZxXAOUJy4VsRpkJo+y9RTnA==",
+      "dependencies": {
+        "cborg": "^4.0.0",
+        "multiformats": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-json": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.2.2.tgz",
+      "integrity": "sha512-NnU8HdHKwAoGyrW3S09NMa8aZw0tImLRyR64hoafpLpDpAbA9g1+fb24JsdlugbL4sXUQVwDVA+qK4Ud8V83lA==",
+      "dependencies": {
+        "cborg": "^4.0.0",
+        "multiformats": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-pb": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.1.2.tgz",
+      "integrity": "sha512-BSztO4l3C+ya9HjCaQot26Y4AVsqIKtnn6+23ubc1usucnf6yoTBme18oCCdM6gKBMxuPqju5ye3lh9WEJsdeQ==",
+      "dependencies": {
+        "multiformats": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -942,6 +1271,739 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
+    },
+    "node_modules/@libp2p/autonat": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/autonat/-/autonat-1.1.5.tgz",
+      "integrity": "sha512-0jad7/bX9m8mkO0ElGAnCLZ1hnYfnCoPQ3CARjx5x0D1niNyukctzuBIhk9c3q73/cSjBompnas8k6hPv2bjtg==",
+      "dependencies": {
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/interface-internal": "^1.3.4",
+        "@libp2p/peer-id": "^4.2.4",
+        "@libp2p/utils": "^5.4.9",
+        "@multiformats/multiaddr": "^12.2.3",
+        "it-first": "^3.0.6",
+        "it-length-prefixed": "^9.0.4",
+        "it-map": "^3.1.0",
+        "it-parallel": "^3.0.7",
+        "it-pipe": "^3.0.1",
+        "protons-runtime": "^5.4.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@libp2p/bootstrap": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/bootstrap/-/bootstrap-10.1.5.tgz",
+      "integrity": "sha512-cXn/Wl7X4uaVGRyh/uSU/crRbhsPkyzH59hzoLP3727f7w82o+sIHVr4SkJcJewt+LZELBLgkJTibZxAntA1dA==",
+      "dependencies": {
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/peer-id": "^4.2.4",
+        "@multiformats/mafmt": "^12.1.6",
+        "@multiformats/multiaddr": "^12.2.3"
+      }
+    },
+    "node_modules/@libp2p/circuit-relay-v2": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/circuit-relay-v2/-/circuit-relay-v2-1.1.5.tgz",
+      "integrity": "sha512-WVIHaj61LJd2JB6vvPikd049NhC2R3vrkuu4T00WJSMNWobmhrKPvFyQMN+1miL6KmdL8Yt1AjK0gog2oT4vDw==",
+      "dependencies": {
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/interface-internal": "^1.3.4",
+        "@libp2p/peer-collections": "^5.2.9",
+        "@libp2p/peer-id": "^4.2.4",
+        "@libp2p/peer-record": "^7.0.25",
+        "@libp2p/utils": "^5.4.9",
+        "@multiformats/mafmt": "^12.1.6",
+        "@multiformats/multiaddr": "^12.2.3",
+        "any-signal": "^4.1.1",
+        "it-protobuf-stream": "^1.1.3",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^13.1.0",
+        "p-defer": "^4.0.1",
+        "progress-events": "^1.0.0",
+        "protons-runtime": "^5.4.0",
+        "race-signal": "^1.0.2",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/crypto": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.1.9.tgz",
+      "integrity": "sha512-8Cf2VKh0uC/rQLvTLSloIOMqUvf4jsSTHXgjWQRf47lDNJlNNI0wSv2S6gakT72GZsRV/jCjYwKPqRlsa5S0iA==",
+      "dependencies": {
+        "@libp2p/interface": "^1.7.0",
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.4.0",
+        "asn1js": "^3.0.5",
+        "multiformats": "^13.1.0",
+        "protons-runtime": "^5.4.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/dcutr": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/dcutr/-/dcutr-1.1.5.tgz",
+      "integrity": "sha512-1zDhZxLxrl+yqIAG9KzyLu3gzyvOT7UYTislw4EwhcMGMviot/pgR87SSVqbT+HDpAoj1sM/3F5VUT/sCDa9WA==",
+      "dependencies": {
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/interface-internal": "^1.3.4",
+        "@libp2p/utils": "^5.4.9",
+        "@multiformats/multiaddr": "^12.2.3",
+        "@multiformats/multiaddr-matcher": "^1.2.1",
+        "delay": "^6.0.0",
+        "it-protobuf-stream": "^1.1.3",
+        "protons-runtime": "^5.4.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@libp2p/identify": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/identify/-/identify-2.1.5.tgz",
+      "integrity": "sha512-uVghY2KfZ3ffDkPmcivfiRDlq1h5rCcoHAW+Kb7JF2qrDfg6BgHAn6IRN4pe/DnYXOuJXIIm6+jjcReTPGBKBQ==",
+      "dependencies": {
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/interface-internal": "^1.3.4",
+        "@libp2p/peer-id": "^4.2.4",
+        "@libp2p/peer-record": "^7.0.25",
+        "@multiformats/multiaddr": "^12.2.3",
+        "@multiformats/multiaddr-matcher": "^1.2.1",
+        "it-drain": "^3.0.7",
+        "it-parallel": "^3.0.7",
+        "it-protobuf-stream": "^1.1.3",
+        "protons-runtime": "^5.4.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0",
+        "wherearewe": "^2.0.1"
+      }
+    },
+    "node_modules/@libp2p/interface": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.7.0.tgz",
+      "integrity": "sha512-/zFyaIaIGW0aihhsH7/93vQdpWInUzFocxF11RO/029Y6h0SVjs24HHbils+DqaFDTqN+L7oNlBx2rM2MnmTjA==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.2.3",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^13.1.0",
+        "progress-events": "^1.0.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@libp2p/interface-internal": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-1.3.4.tgz",
+      "integrity": "sha512-8x/0sdeH8T16yZ9t/Cfja0ms6Ho9fF3riX56WhQrNxMU6C1sIgAFmzUNzHLxxOR+rkKyL9cyXIyB+RcBf4gzjA==",
+      "dependencies": {
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/peer-collections": "^5.2.9",
+        "@multiformats/multiaddr": "^12.2.3",
+        "progress-events": "^1.0.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@libp2p/kad-dht": {
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/kad-dht/-/kad-dht-12.1.5.tgz",
+      "integrity": "sha512-n/Tdd3zVa2p1S4L6wRIBUAo3ctCbiEkp1aewpOUthL6rOwBh6U/RQ+dssiZNEDHCsF1ta/mZkREuXqxOPpplFQ==",
+      "dependencies": {
+        "@libp2p/crypto": "^4.1.9",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/interface-internal": "^1.3.4",
+        "@libp2p/peer-collections": "^5.2.9",
+        "@libp2p/peer-id": "^4.2.4",
+        "@libp2p/record": "^4.0.4",
+        "@libp2p/utils": "^5.4.9",
+        "@multiformats/multiaddr": "^12.2.3",
+        "any-signal": "^4.1.1",
+        "hashlru": "^2.3.0",
+        "interface-datastore": "^8.2.11",
+        "it-drain": "^3.0.7",
+        "it-length": "^3.0.6",
+        "it-length-prefixed": "^9.0.4",
+        "it-map": "^3.1.0",
+        "it-merge": "^3.0.5",
+        "it-parallel": "^3.0.7",
+        "it-pipe": "^3.0.1",
+        "it-protobuf-stream": "^1.1.3",
+        "it-take": "^3.0.5",
+        "multiformats": "^13.1.0",
+        "p-defer": "^4.0.1",
+        "p-event": "^6.0.1",
+        "p-queue": "^8.0.1",
+        "progress-events": "^1.0.0",
+        "protons-runtime": "^5.4.0",
+        "race-signal": "^1.0.2",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/keychain": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/keychain/-/keychain-4.1.6.tgz",
+      "integrity": "sha512-HZ5VhKPAqItMWY/5jfXaFMKCddAxYuybgn0j3v3hZnnHQ2HyeLJnUvDd5yjM7L3DxMDLdetK2rdocrdtqjdWkA==",
+      "dependencies": {
+        "@libp2p/crypto": "^4.1.9",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/peer-id": "^4.2.4",
+        "interface-datastore": "^8.2.11",
+        "merge-options": "^3.0.4",
+        "multiformats": "^13.1.0",
+        "sanitize-filename": "^1.6.3",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/logger": {
+      "version": "4.0.20",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-4.0.20.tgz",
+      "integrity": "sha512-TTh2dhHsOTAlMPxSa9ncFPHa/0jTt+0AQxwHdlxg/OGLAgc9VRhnrhHUbJZp07Crcw4T/MOfS4KhjlxgqYgJRw==",
+      "dependencies": {
+        "@libp2p/interface": "^1.7.0",
+        "@multiformats/multiaddr": "^12.2.3",
+        "interface-datastore": "^8.2.11",
+        "multiformats": "^13.1.0",
+        "weald": "^1.0.2"
+      }
+    },
+    "node_modules/@libp2p/mdns": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/mdns/-/mdns-10.1.5.tgz",
+      "integrity": "sha512-iSBnjaUgPdPudXP3ZPXJMWzJkT+I+TQHRCBTh6OMPa0V2C/MhL+FfCGn0SDMWKSDDwqK6I6UOeTflf4YUzy/8w==",
+      "dependencies": {
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/interface-internal": "^1.3.4",
+        "@libp2p/peer-id": "^4.2.4",
+        "@libp2p/utils": "^5.4.9",
+        "@multiformats/multiaddr": "^12.2.3",
+        "@types/multicast-dns": "^7.2.4",
+        "dns-packet": "^5.6.1",
+        "multicast-dns": "^7.2.5"
+      }
+    },
+    "node_modules/@libp2p/mplex": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-10.1.5.tgz",
+      "integrity": "sha512-NdT9ak8omeJZvdJhzsKSSeHBZlP+3sl68UbrpfVanWebQVuNqw7UOLURKtXnRd7II7siXt37Yq6W2km7VIT1yQ==",
+      "deprecated": "Mplex has no flow control - please use @chainsafe/libp2p-yamux instead",
+      "dependencies": {
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/utils": "^5.4.9",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/multistream-select": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-6.0.2.tgz",
+      "integrity": "sha512-hggL4MxSK/o7Q/o5d/qte4VQgJY646NvcieJP1yc7TYELAVNEQRhvG7yzZytJsqfV5PlFZQtEy6Ox+n4oCk5tA==",
+      "dependencies": {
+        "@libp2p/interface": "^2.1.0",
+        "it-length-prefixed": "^9.0.4",
+        "it-length-prefixed-stream": "^1.1.7",
+        "it-stream-types": "^2.0.1",
+        "p-defer": "^4.0.1",
+        "race-signal": "^1.0.2",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/multistream-select/node_modules/@libp2p/interface": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.1.0.tgz",
+      "integrity": "sha512-22TD1KMP29xzlzYNH5zpi3E3WvshNC+MeYm1arD7PjLYvQLYKsm+HVaTVweLtqvuEVjMNNB4Q5JLNelM2tELgA==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.2.3",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^13.1.0",
+        "progress-events": "^1.0.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@libp2p/peer-collections": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-5.2.9.tgz",
+      "integrity": "sha512-8gBmzQlCWjjb+FSQBKK33T25Y5Df/8FWCXFtJDsprVxVUzDOQoibQJ5Tb4Y+mb96HUhNzoaRWVEamB78MMB3DA==",
+      "dependencies": {
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/peer-id": "^4.2.4",
+        "@libp2p/utils": "^5.4.9"
+      }
+    },
+    "node_modules/@libp2p/peer-id": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-4.2.4.tgz",
+      "integrity": "sha512-mvvsVxt4HkF14BrTNKbqr14VObW+KBJBWu1Oe6BFCoDttGMQLaI+PdduE1r6Tquntv5IONBqoITgD7ow5dQ+vQ==",
+      "dependencies": {
+        "@libp2p/interface": "^1.7.0",
+        "multiformats": "^13.1.0",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/peer-id-factory": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-4.2.4.tgz",
+      "integrity": "sha512-NDQ/qIWpcAG/6xQjyut6xCkrYYAoCaI/33Z+7yzo5qFODwLfNonLzSTasnA6jhuvHn33aHnD1qhdpFkmstxtNQ==",
+      "dependencies": {
+        "@libp2p/crypto": "^4.1.9",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/peer-id": "^4.2.4",
+        "protons-runtime": "^5.4.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/peer-record": {
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-7.0.25.tgz",
+      "integrity": "sha512-b54P3cSeQniW/HPJjBVbeF3KaVUQkWa431gotuIFUS1PYgtz69uzkRrVY6Qt+RBb4R4fcmH4K4jWyZi3xyLGfQ==",
+      "dependencies": {
+        "@libp2p/crypto": "^4.1.9",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/peer-id": "^4.2.4",
+        "@libp2p/utils": "^5.4.9",
+        "@multiformats/multiaddr": "^12.2.3",
+        "protons-runtime": "^5.4.0",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/peer-store": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-11.0.2.tgz",
+      "integrity": "sha512-qiXJAqlIV/Xemjt8uBWUbRT+tdYkb4qOGwERK4kOzh9wKMphvk+XXSpRzEdwZs1aX9DMMYqcrPjZY5A7W+K1Jg==",
+      "dependencies": {
+        "@libp2p/crypto": "^5.0.2",
+        "@libp2p/interface": "^2.1.0",
+        "@libp2p/peer-collections": "^6.0.2",
+        "@libp2p/peer-id": "^5.0.2",
+        "@libp2p/peer-record": "^8.0.2",
+        "@multiformats/multiaddr": "^12.2.3",
+        "interface-datastore": "^8.3.0",
+        "it-all": "^3.0.6",
+        "mortice": "^3.0.4",
+        "multiformats": "^13.1.0",
+        "protons-runtime": "^5.4.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/@libp2p/crypto": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.0.2.tgz",
+      "integrity": "sha512-eThU7WT/axsypyxiuejYs42Si4htgt3IunmhCZ9pSFmtiBNVnRrqij9/yTgMMXH/2NNkq/8Zq4jLm3cZ5XoAqg==",
+      "dependencies": {
+        "@libp2p/interface": "^2.1.0",
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.4.0",
+        "asn1js": "^3.0.5",
+        "multiformats": "^13.1.0",
+        "protons-runtime": "^5.4.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/@libp2p/interface": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.1.0.tgz",
+      "integrity": "sha512-22TD1KMP29xzlzYNH5zpi3E3WvshNC+MeYm1arD7PjLYvQLYKsm+HVaTVweLtqvuEVjMNNB4Q5JLNelM2tELgA==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.2.3",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^13.1.0",
+        "progress-events": "^1.0.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/@libp2p/logger": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-5.0.2.tgz",
+      "integrity": "sha512-sUE/clwUQQDiPxrtwmfVJjz8B1to713XziTvs9WqEdU6AkoOQV7S18aosvUw3+AjuBMpthYst1gewRkWivH7ag==",
+      "dependencies": {
+        "@libp2p/interface": "^2.1.0",
+        "@multiformats/multiaddr": "^12.2.3",
+        "interface-datastore": "^8.3.0",
+        "multiformats": "^13.1.0",
+        "weald": "^1.0.2"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/@libp2p/peer-collections": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-6.0.2.tgz",
+      "integrity": "sha512-rpjpXWtX355l9Y0cR/LdvEPsnvbkuRXD47/RPI5Sph654LmMUzxtfoohoyReAU+UUFWt881Oq9rQBe8wkwM3UA==",
+      "dependencies": {
+        "@libp2p/interface": "^2.1.0",
+        "@libp2p/peer-id": "^5.0.2",
+        "@libp2p/utils": "^6.0.2",
+        "multiformats": "^13.2.2"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/@libp2p/peer-id": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-5.0.2.tgz",
+      "integrity": "sha512-e+9yrSOLh3vUIYmjNb1UwNJ/eRFWcZ0XAze4KIBtmAg3i4MHeO6KKiskpGUBv1AmKWLzfhruLQYSXoPOo943gg==",
+      "dependencies": {
+        "@libp2p/crypto": "^5.0.2",
+        "@libp2p/interface": "^2.1.0",
+        "multiformats": "^13.1.0",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/@libp2p/peer-record": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-8.0.2.tgz",
+      "integrity": "sha512-zPBf2WkaqF0YxGogEuB+0cxFXdARlr2C5f9dM5va639aROQGm7m8g778Z967Ur+LCAZbjHBgRw/Uho4swg6ZnA==",
+      "dependencies": {
+        "@libp2p/crypto": "^5.0.2",
+        "@libp2p/interface": "^2.1.0",
+        "@libp2p/peer-id": "^5.0.2",
+        "@libp2p/utils": "^6.0.2",
+        "@multiformats/multiaddr": "^12.2.3",
+        "multiformats": "^13.2.2",
+        "protons-runtime": "^5.4.0",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/peer-store/node_modules/@libp2p/utils": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-6.0.2.tgz",
+      "integrity": "sha512-W+yo41vLulZkj7FoyMNwncSWJBCbRzzQR9IgA9K/wCII9WzSHDZ/lo6yZXCKW64Tft50cXqW8Cb5Vr/TQcWUWA==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.2",
+        "@libp2p/crypto": "^5.0.2",
+        "@libp2p/interface": "^2.1.0",
+        "@libp2p/logger": "^5.0.2",
+        "@multiformats/multiaddr": "^12.2.3",
+        "@multiformats/multiaddr-matcher": "^1.2.1",
+        "@sindresorhus/fnv1a": "^3.1.0",
+        "@types/murmurhash3js-revisited": "^3.0.3",
+        "any-signal": "^4.1.1",
+        "delay": "^6.0.0",
+        "get-iterator": "^2.0.1",
+        "is-loopback-addr": "^2.0.2",
+        "it-foreach": "^2.1.1",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "murmurhash3js-revisited": "^3.0.0",
+        "netmask": "^2.0.2",
+        "p-defer": "^4.0.1",
+        "race-event": "^1.3.0",
+        "race-signal": "^1.0.2",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/ping": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/ping/-/ping-1.1.6.tgz",
+      "integrity": "sha512-tzTL0BzS1JaHE8v4PhRZ5K8wQQQcTMXM/0baCkLTLIaSMe1fzhj+KHbFNoUrY3yni4yfsVY1uR0qchhc1/J9qg==",
+      "dependencies": {
+        "@libp2p/crypto": "^4.1.9",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/interface-internal": "^1.3.4",
+        "@multiformats/multiaddr": "^12.2.3",
+        "it-first": "^3.0.6",
+        "it-pipe": "^3.0.1",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/pubsub-peer-discovery": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/pubsub-peer-discovery/-/pubsub-peer-discovery-10.0.3.tgz",
+      "integrity": "sha512-9UL7j24SoXBHPulUUWpHiFjrI1rdbIZS8mN4+tRCF8e9J99fr7EcHpyN/kB0o31KXDKFA6zr8H0hniHhuqMPKA==",
+      "dependencies": {
+        "@libp2p/interface": "^1.0.1",
+        "@libp2p/interface-internal": "^1.0.1",
+        "@libp2p/peer-id": "^4.0.1",
+        "@multiformats/multiaddr": "^12.0.0",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^5.0.2"
+      }
+    },
+    "node_modules/@libp2p/record": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/record/-/record-4.0.4.tgz",
+      "integrity": "sha512-wEEeHXGNIcc8HtGbgGMuSHbboUWMxKG7OxALFwkE+KACgfRJZTESOp6XIdZnyC0r9lfEFsjF01pFKBTzoBmWEQ==",
+      "dependencies": {
+        "protons-runtime": "^5.4.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/tcp": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-9.1.6.tgz",
+      "integrity": "sha512-zbhHDY5txl8ypCL50JQWej/fZ8X7Lh+qfZw1HXDQEJZvgIrdYDPXrXfjIFflN0m/6hPoU/VAkKOr+RIuhIE8wQ==",
+      "dependencies": {
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/utils": "^5.4.9",
+        "@multiformats/mafmt": "^12.1.6",
+        "@multiformats/multiaddr": "^12.2.3",
+        "@types/sinon": "^17.0.3",
+        "progress-events": "^1.0.0",
+        "stream-to-it": "^1.0.1"
+      }
+    },
+    "node_modules/@libp2p/upnp-nat": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/upnp-nat/-/upnp-nat-1.2.5.tgz",
+      "integrity": "sha512-bxW4jB4p4T/i8V5BrwUzPLsQvFleC7EZIkqS0r8JbNiFy5iYIvU/WOMB6s7VJkiX3m1RxOxkKU6DcuAPuIJPzQ==",
+      "dependencies": {
+        "@achingbrain/nat-port-mapper": "^1.0.13",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/interface-internal": "^1.3.4",
+        "@libp2p/utils": "^5.4.9",
+        "@multiformats/multiaddr": "^12.2.3",
+        "wherearewe": "^2.0.1"
+      }
+    },
+    "node_modules/@libp2p/utils": {
+      "version": "5.4.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-5.4.9.tgz",
+      "integrity": "sha512-0fRdX98WqhTmXU2WEVLegLFxs/kKTtUHanHk5Lzs4oGsIzlPHR7zE6lj/U1WfsFA+Xo1eYQpNLiXEL29hG+Nyw==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.2",
+        "@libp2p/crypto": "^4.1.9",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/logger": "^4.0.20",
+        "@multiformats/multiaddr": "^12.2.3",
+        "@multiformats/multiaddr-matcher": "^1.2.1",
+        "@sindresorhus/fnv1a": "^3.1.0",
+        "@types/murmurhash3js-revisited": "^3.0.3",
+        "any-signal": "^4.1.1",
+        "delay": "^6.0.0",
+        "get-iterator": "^2.0.1",
+        "is-loopback-addr": "^2.0.2",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "murmurhash3js-revisited": "^3.0.0",
+        "netmask": "^2.0.2",
+        "p-defer": "^4.0.1",
+        "race-event": "^1.3.0",
+        "race-signal": "^1.0.2",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/webrtc": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/webrtc/-/webrtc-4.1.10.tgz",
+      "integrity": "sha512-3NSntJ5DYeq4xlM9gekFkjJH2pqYD+pUQtTilRU1lFgPtGs9bbWmZr3mtsK3QaMyryvKT8GoqcR+cSgyZ2LYjQ==",
+      "dependencies": {
+        "@chainsafe/libp2p-noise": "^15.0.0",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/interface-internal": "^1.3.4",
+        "@libp2p/peer-id": "^4.2.4",
+        "@libp2p/utils": "^5.4.9",
+        "@multiformats/mafmt": "^12.1.6",
+        "@multiformats/multiaddr": "^12.2.3",
+        "@multiformats/multiaddr-matcher": "^1.2.1",
+        "detect-browser": "^5.3.0",
+        "it-length-prefixed": "^9.0.4",
+        "it-protobuf-stream": "^1.1.3",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^13.1.0",
+        "node-datachannel": "^0.11.0",
+        "p-defer": "^4.0.1",
+        "p-event": "^6.0.1",
+        "p-timeout": "^6.1.2",
+        "progress-events": "^1.0.0",
+        "protons-runtime": "^5.4.0",
+        "race-signal": "^1.0.2",
+        "react-native-webrtc": "^118.0.7",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/websockets": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-9.0.2.tgz",
+      "integrity": "sha512-pMSuvgiN+aouRpmGA/rlaH2PP51d+/m/+8N5qxFSoByV0KHC1F+uMvMPCzV8xMIm43H8zYJn5N0TILKsWZRoKw==",
+      "dependencies": {
+        "@libp2p/interface": "^2.1.0",
+        "@libp2p/utils": "^6.0.2",
+        "@multiformats/mafmt": "^12.1.6",
+        "@multiformats/multiaddr": "^12.2.3",
+        "@multiformats/multiaddr-to-uri": "^10.0.1",
+        "@types/ws": "^8.5.10",
+        "it-ws": "^6.1.1",
+        "p-defer": "^4.0.1",
+        "progress-events": "^1.0.0",
+        "race-signal": "^1.0.2",
+        "wherearewe": "^2.0.1",
+        "ws": "^8.17.0"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/@libp2p/crypto": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.0.2.tgz",
+      "integrity": "sha512-eThU7WT/axsypyxiuejYs42Si4htgt3IunmhCZ9pSFmtiBNVnRrqij9/yTgMMXH/2NNkq/8Zq4jLm3cZ5XoAqg==",
+      "dependencies": {
+        "@libp2p/interface": "^2.1.0",
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.4.0",
+        "asn1js": "^3.0.5",
+        "multiformats": "^13.1.0",
+        "protons-runtime": "^5.4.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/@libp2p/interface": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.1.0.tgz",
+      "integrity": "sha512-22TD1KMP29xzlzYNH5zpi3E3WvshNC+MeYm1arD7PjLYvQLYKsm+HVaTVweLtqvuEVjMNNB4Q5JLNelM2tELgA==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.2.3",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^13.1.0",
+        "progress-events": "^1.0.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/@libp2p/logger": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-5.0.2.tgz",
+      "integrity": "sha512-sUE/clwUQQDiPxrtwmfVJjz8B1to713XziTvs9WqEdU6AkoOQV7S18aosvUw3+AjuBMpthYst1gewRkWivH7ag==",
+      "dependencies": {
+        "@libp2p/interface": "^2.1.0",
+        "@multiformats/multiaddr": "^12.2.3",
+        "interface-datastore": "^8.3.0",
+        "multiformats": "^13.1.0",
+        "weald": "^1.0.2"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/@libp2p/utils": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-6.0.2.tgz",
+      "integrity": "sha512-W+yo41vLulZkj7FoyMNwncSWJBCbRzzQR9IgA9K/wCII9WzSHDZ/lo6yZXCKW64Tft50cXqW8Cb5Vr/TQcWUWA==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.2",
+        "@libp2p/crypto": "^5.0.2",
+        "@libp2p/interface": "^2.1.0",
+        "@libp2p/logger": "^5.0.2",
+        "@multiformats/multiaddr": "^12.2.3",
+        "@multiformats/multiaddr-matcher": "^1.2.1",
+        "@sindresorhus/fnv1a": "^3.1.0",
+        "@types/murmurhash3js-revisited": "^3.0.3",
+        "any-signal": "^4.1.1",
+        "delay": "^6.0.0",
+        "get-iterator": "^2.0.1",
+        "is-loopback-addr": "^2.0.2",
+        "it-foreach": "^2.1.1",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "murmurhash3js-revisited": "^3.0.0",
+        "netmask": "^2.0.2",
+        "p-defer": "^4.0.1",
+        "race-event": "^1.3.0",
+        "race-signal": "^1.0.2",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@libp2p/webtransport": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/webtransport/-/webtransport-4.1.9.tgz",
+      "integrity": "sha512-A48Fl8pm4Tstc5hiOvMbqVKS4/98D0pCn/Cb8iv/RS/EFyfMDBF8qSm4aYN9pXF0m0OepBKP4VG2GAGVqnqfrA==",
+      "dependencies": {
+        "@chainsafe/libp2p-noise": "^15.0.0",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/peer-id": "^4.2.4",
+        "@libp2p/utils": "^5.4.9",
+        "@multiformats/multiaddr": "^12.2.3",
+        "@multiformats/multiaddr-matcher": "^1.2.1",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^13.1.0",
+        "progress-events": "^1.0.0",
+        "race-signal": "^1.0.2",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@multiformats/dns": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.6.tgz",
+      "integrity": "sha512-nt/5UqjMPtyvkG9BQYdJ4GfLK3nMqGpFZOzf4hAmIa0sJh2LlS9YKXZ4FgwBDsaHvzZqR/rUFIywIc7pkHNNuw==",
+      "dependencies": {
+        "@types/dns-packet": "^5.6.5",
+        "buffer": "^6.0.3",
+        "dns-packet": "^5.6.1",
+        "hashlru": "^2.3.0",
+        "p-queue": "^8.0.1",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^5.0.2"
+      }
+    },
+    "node_modules/@multiformats/mafmt": {
+      "version": "12.1.6",
+      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-12.1.6.tgz",
+      "integrity": "sha512-tlJRfL21X+AKn9b5i5VnaTD6bNttpSpcqwKVmDmSHLwxoz97fAHaepqFOk/l1fIu94nImIXneNbhsJx/RQNIww==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr": {
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.3.1.tgz",
+      "integrity": "sha512-yoGODQY4nIj41ENJClucS8FtBoe8w682bzbKldEQr9lSlfdHqAsRC+vpJAOBpiMwPps1tHua4kxrDmvprdhoDQ==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@multiformats/dns": "^1.0.3",
+        "multiformats": "^13.0.0",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr-matcher": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-matcher/-/multiaddr-matcher-1.2.4.tgz",
+      "integrity": "sha512-GgpqzQFL4Mj8t7cLNHC5nuYUuSm0kTtSUyYswiyWwTSUY3XwRAMx0UiFWQg+ETk0u+/IvFaHxfnyEoH3tasvwg==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@multiformats/multiaddr": "^12.0.0",
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr-to-uri": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-10.1.0.tgz",
+      "integrity": "sha512-ZNwSAx3ssBWwd4y0LKrOsq9xG7LBHboQxnUdSduNc2fTh/NS1UjA2slgUy6KHxH5k9S2DSus0iU2CoyJyN0/pg==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.3.0"
+      }
+    },
+    "node_modules/@multiformats/uri-to-multiaddr": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/uri-to-multiaddr/-/uri-to-multiaddr-8.0.0.tgz",
+      "integrity": "sha512-86O+gY6JTnCv0O/IxTKV+1+GACoEBTr5Cfyh+FdzStWneviz2AZwLK8Hsys5dbfMgT//Vs7FolMiEHURlCel8w==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.1.14",
+        "is-ip": "^5.0.0"
       }
     },
     "node_modules/@next/env": {
@@ -1091,6 +2153,14 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.6.0.tgz",
+      "integrity": "sha512-mIbq/R9QXk5/cTfESb1OKtyFnk7oc1Om/8onA1158K9/OZUQFDEVy55jVTato+xmp3XX6F6Qh0zz0Nc1AxAlRQ==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/curves": {
@@ -1902,6 +2972,17 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@sindresorhus/fnv1a": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/fnv1a/-/fnv1a-3.1.0.tgz",
+      "integrity": "sha512-KV321z5m/0nuAg83W1dPLy85HpHDk7Sdi4fJbwvacWsEhAh+rZUW4ZfGcXmUIvjZg4ss2bcwNlRhJ7GBEUG08w==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@substrate/connect": {
       "version": "0.8.10",
       "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.8.10.tgz",
@@ -2419,11 +3500,33 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/dns-packet": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.5.tgz",
+      "integrity": "sha512-qXOC7XLOEe43ehtWJCMnQXvgcIpv6rPmQ1jXT98Ad8A3TB1Ue50jsCbSSSyuazScEuZ/Q026vHbrOTVkmwA+7Q==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/multicast-dns": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/@types/multicast-dns/-/multicast-dns-7.2.4.tgz",
+      "integrity": "sha512-ib5K4cIDR4Ro5SR3Sx/LROkMDa0BHz0OPaCBL/OSPDsAXEGZ3/KQeS6poBKYVN7BfjXDL9lWNwzyHVgt/wkyCw==",
+      "dependencies": {
+        "@types/dns-packet": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/murmurhash3js-revisited": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.3.tgz",
+      "integrity": "sha512-QvlqvYtGBYIDeO8dFdY4djkRubcrc+yTJtBc7n8VZPlJDUS/00A+PssbvERM8f9bYRmcaSEHPZgZojeQj7kzAA=="
     },
     "node_modules/@types/node": {
       "version": "20.12.12",
@@ -2456,6 +3559,32 @@
       "dev": true,
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow=="
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
+      "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ=="
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
+      "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -2657,6 +3786,15 @@
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true
+    },
+    "node_modules/any-signal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -2860,6 +3998,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+      "dependencies": {
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -2973,6 +4124,55 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/blockstore-core": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/blockstore-core/-/blockstore-core-4.4.1.tgz",
+      "integrity": "sha512-peXfL9ZLx1cb84QALocMjhT8CsQ4JsreI/AitlN1inipSdC/G+jcYVJCqeCD5ecSTv/0LMpg8NlAPH/eBYZLjA==",
+      "dependencies": {
+        "@libp2p/logger": "^4.0.6",
+        "err-code": "^3.0.1",
+        "interface-blockstore": "^5.0.0",
+        "interface-store": "^5.0.0",
+        "it-drain": "^3.0.5",
+        "it-filter": "^3.0.4",
+        "it-merge": "^3.0.3",
+        "it-pushable": "^3.2.3",
+        "multiformats": "^13.0.1"
+      }
+    },
     "node_modules/bn.js": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
@@ -2999,6 +4199,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/browser-readablestream-to-it": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-2.0.7.tgz",
+      "integrity": "sha512-g1Aznml3HmqTLSXylZhGwdfnAa67+vlNAYhT9ROJZkAxY7yYmWusND10olvCMPe4sVhZyVwn5tPkRzOg85kBEg=="
     },
     "node_modules/browserslist": {
       "version": "4.23.0",
@@ -3122,6 +4327,14 @@
         }
       ]
     },
+    "node_modules/cborg": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.3.tgz",
+      "integrity": "sha512-XBFbEJ6WMfn9L7woc2t+EzOxF8vGqddoopKBbrhIvZBt2WIUgSlT8xLmM6Aq1xv8eWt4yOSjwxWjYeuHU3CpJA==",
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3183,10 +4396,29 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/clone-regexp": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-3.0.0.tgz",
+      "integrity": "sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw==",
+      "dependencies": {
+        "is-regexp": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -3229,11 +4461,21 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/convert-hrtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -3348,6 +4590,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/datastore-core": {
+      "version": "9.2.9",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-9.2.9.tgz",
+      "integrity": "sha512-wraWTPsbtdE7FFaVo3pwPuTB/zXsgwGGAm8BgBYwYAuzZCTS0MfXmd/HH1vR9s0/NFFjOVmBkGiWCvKxZ+QjVw==",
+      "dependencies": {
+        "@libp2p/logger": "^4.0.6",
+        "err-code": "^3.0.1",
+        "interface-datastore": "^8.0.0",
+        "interface-store": "^5.0.0",
+        "it-drain": "^3.0.5",
+        "it-filter": "^3.0.4",
+        "it-map": "^3.0.5",
+        "it-merge": "^3.0.3",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.2.3",
+        "it-sort": "^3.0.4",
+        "it-take": "^3.0.4"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -3364,11 +4625,44 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/default-gateway": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-7.2.2.tgz",
+      "integrity": "sha512-AD7TrdNNPXRZIGw63dw+lnGmT4v7ggZC5NHNJgAYWm5njrwoze1q5JSAW9YuLy2tjnoLUG/r8FEB93MCh9QJPg==",
+      "dependencies": {
+        "execa": "^7.1.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -3404,6 +4698,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delay": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-6.0.0.tgz",
+      "integrity": "sha512-2NJozoOHQ4NuZuVIr5CWd0iiLVIRSDepakaovIN+9eIDHEhdCAEvSy2cuf1DCrPPQLvHmbqTHODlhHg8UCy4zw==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3411,6 +4716,19 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/detect-browser": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/didyoumean": {
@@ -3436,6 +4754,17 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true
+    },
+    "node_modules/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -3467,6 +4796,14 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.16.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.1.tgz",
@@ -3479,6 +4816,11 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/err-code": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
     },
     "node_modules/es-abstract": {
       "version": "1.23.3",
@@ -4148,6 +5490,22 @@
         "es5-ext": "~0.10.14"
       }
     },
+    "node_modules/event-iterator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/event-iterator/-/event-iterator-2.0.0.tgz",
+      "integrity": "sha512-KGft0ldl31BZVV//jj+IAIGCxkvvUkkON+ScH6zfoX+l+omX6001ggyRSpI0Io2Hlro0ThXotswCtfzS8UkIiQ=="
+    },
+    "node_modules/event-target-shim": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -4160,6 +5518,41 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/execa": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^4.3.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ext": {
@@ -4381,6 +5774,20 @@
         }
       }
     },
+    "node_modules/freeport-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/freeport-promise/-/freeport-promise-2.0.0.tgz",
+      "integrity": "sha512-dwWpT1DdQcwrhmRwnDnPM/ZFny+FtzU+k50qF2eid3KxaQDsMiBrwo1i0G3qSugkN5db6Cb0zgfc68QeTOpEFg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4394,6 +5801,17 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function-timeout": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-0.1.1.tgz",
+      "integrity": "sha512-0NVVC0TaP7dSTvn1yMiy6d6Q8gifzbvQafO46RtLG/kHJUBNd+pVRGOBoK44wNBvtSPUJRfdVvkFdD3p0xvyZg==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/function.prototype.name": {
@@ -4442,6 +5860,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-iterator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-2.0.1.tgz",
+      "integrity": "sha512-7HuY/hebu4gryTDT7O/XY/fvY9wRByEGdK6QOa4of8npTcv0+NS6frFKABcf6S9EBAsveTuKTsZQQBFMMNILIg=="
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
@@ -4470,6 +5904,11 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "node_modules/glob": {
       "version": "10.3.10",
@@ -4682,6 +6121,11 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -4692,6 +6136,140 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helia": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/helia/-/helia-4.2.6.tgz",
+      "integrity": "sha512-qa/ADpLRRqzQHchd0XqpC4cVj9+OC4BA4QldN6dxBO0OLuGoUEo6kGrbpkygqNQ8RupA1ViFBWP7TqX6OIrppg==",
+      "dependencies": {
+        "@chainsafe/libp2p-noise": "^15.0.0",
+        "@chainsafe/libp2p-yamux": "^6.0.2",
+        "@helia/block-brokers": "^3.0.4",
+        "@helia/delegated-routing-v1-http-api-client": "^3.0.0",
+        "@helia/interface": "^4.3.1",
+        "@helia/routers": "^1.1.1",
+        "@helia/utils": "^0.3.3",
+        "@libp2p/autonat": "^1.0.13",
+        "@libp2p/bootstrap": "^10.0.16",
+        "@libp2p/circuit-relay-v2": "^1.0.16",
+        "@libp2p/dcutr": "^1.0.13",
+        "@libp2p/identify": "^2.0.0",
+        "@libp2p/interface": "^1.1.4",
+        "@libp2p/kad-dht": "^12.0.8",
+        "@libp2p/keychain": "^4.0.9",
+        "@libp2p/logger": "^4.0.7",
+        "@libp2p/mdns": "^10.0.16",
+        "@libp2p/mplex": "^10.0.16",
+        "@libp2p/ping": "^1.0.12",
+        "@libp2p/tcp": "^9.0.16",
+        "@libp2p/upnp-nat": "^1.0.14",
+        "@libp2p/webrtc": "^4.0.20",
+        "@libp2p/websockets": "^8.0.16",
+        "@libp2p/webtransport": "^4.0.20",
+        "@multiformats/dns": "^1.0.1",
+        "blockstore-core": "^4.4.0",
+        "datastore-core": "^9.2.9",
+        "interface-blockstore": "^5.2.10",
+        "interface-datastore": "^8.2.11",
+        "ipns": "^9.0.0",
+        "libp2p": "^1.3.0",
+        "multiformats": "^13.1.0"
+      }
+    },
+    "node_modules/helia/node_modules/@libp2p/multistream-select": {
+      "version": "5.1.17",
+      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-5.1.17.tgz",
+      "integrity": "sha512-QOMGjCzKGf/W+qzWw5OxaqLEYhK45XjMCxGJYQ7L5eUkcwAv6rlPZAYw6YslaMLpJTa61/yfh8D4u7EuoMFsUw==",
+      "dependencies": {
+        "@libp2p/interface": "^1.7.0",
+        "it-length-prefixed": "^9.0.4",
+        "it-length-prefixed-stream": "^1.1.7",
+        "it-stream-types": "^2.0.1",
+        "p-defer": "^4.0.1",
+        "race-signal": "^1.0.2",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/helia/node_modules/@libp2p/peer-store": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-10.1.5.tgz",
+      "integrity": "sha512-JqQcIcxZS7kicCPabGRyrKD+qZlOdaooL00hdHogVb4MIMqfjiQMmOEpzIvTQLCKHKM2mmfnV3P7kc6hYzPq8g==",
+      "dependencies": {
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/peer-collections": "^5.2.9",
+        "@libp2p/peer-id": "^4.2.4",
+        "@libp2p/peer-record": "^7.0.25",
+        "@multiformats/multiaddr": "^12.2.3",
+        "interface-datastore": "^8.2.11",
+        "it-all": "^3.0.6",
+        "mortice": "^3.0.4",
+        "multiformats": "^13.1.0",
+        "protons-runtime": "^5.4.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/helia/node_modules/@libp2p/websockets": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-8.2.0.tgz",
+      "integrity": "sha512-UNjqkQ8/emnYswp1ohIIuZCnhI5DlvWF9IaIND2MoTCDavi7yubWfMp8jSWBsAqPnMeLMO8MQ6YlOo4FFC104Q==",
+      "dependencies": {
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/utils": "^5.4.9",
+        "@multiformats/mafmt": "^12.1.6",
+        "@multiformats/multiaddr": "^12.2.3",
+        "@multiformats/multiaddr-to-uri": "^10.0.1",
+        "@types/ws": "^8.5.10",
+        "it-ws": "^6.1.1",
+        "p-defer": "^4.0.1",
+        "progress-events": "^1.0.0",
+        "race-signal": "^1.0.2",
+        "wherearewe": "^2.0.1",
+        "ws": "^8.17.0"
+      }
+    },
+    "node_modules/helia/node_modules/libp2p": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-1.9.4.tgz",
+      "integrity": "sha512-OCMQqJ0Po8jhgb4CilWhI5EWhppn9ENdhg63PQL8Yi1tk2rOwJJt+NBec85AU18zBc0jv7Q6SgQRkzCefAuyIQ==",
+      "dependencies": {
+        "@libp2p/crypto": "^4.1.9",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/interface-internal": "^1.3.4",
+        "@libp2p/logger": "^4.0.20",
+        "@libp2p/multistream-select": "^5.1.17",
+        "@libp2p/peer-collections": "^5.2.9",
+        "@libp2p/peer-id": "^4.2.4",
+        "@libp2p/peer-id-factory": "^4.2.4",
+        "@libp2p/peer-store": "^10.1.5",
+        "@libp2p/utils": "^5.4.9",
+        "@multiformats/dns": "^1.0.6",
+        "@multiformats/multiaddr": "^12.2.3",
+        "@multiformats/multiaddr-matcher": "^1.2.1",
+        "any-signal": "^4.1.1",
+        "datastore-core": "^9.2.9",
+        "interface-datastore": "^8.2.11",
+        "it-byte-stream": "^1.0.12",
+        "it-merge": "^3.0.5",
+        "it-parallel": "^3.0.7",
+        "merge-options": "^3.0.4",
+        "multiformats": "^13.1.0",
+        "p-defer": "^4.0.1",
+        "progress-events": "^1.0.0",
+        "race-event": "^1.3.0",
+        "race-signal": "^1.0.2",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/ieee754": {
@@ -4763,6 +6341,44 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/interface-blockstore": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-5.3.1.tgz",
+      "integrity": "sha512-nhgrQnz6yUQEqxTFLhlOBurQOy5lWlwCpgFmZ3GTObTVTQS9RZjK/JTozY6ty9uz2lZs7VFJSqwjWAltorJ4Vw==",
+      "dependencies": {
+        "interface-store": "^6.0.0",
+        "multiformats": "^13.2.3"
+      }
+    },
+    "node_modules/interface-blockstore/node_modules/interface-store": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-6.0.2.tgz",
+      "integrity": "sha512-KSFCXtBlNoG0hzwNa0RmhHtrdhzexp+S+UY2s0rWTBJyfdEIgn6i6Zl9otVqrcFYbYrneBT7hbmHQ8gE0C3umA=="
+    },
+    "node_modules/interface-datastore": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.3.1.tgz",
+      "integrity": "sha512-3r0ETmHIi6HmvM5sc09QQiCD3gUfwtEM/AAChOyAd/UAKT69uk8LXfTSUBufbUIO/dU65Vj8nb9O6QjwW8vDSQ==",
+      "dependencies": {
+        "interface-store": "^6.0.0",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/interface-datastore/node_modules/interface-store": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-6.0.2.tgz",
+      "integrity": "sha512-KSFCXtBlNoG0hzwNa0RmhHtrdhzexp+S+UY2s0rWTBJyfdEIgn6i6Zl9otVqrcFYbYrneBT7hbmHQ8gE0C3umA=="
+    },
+    "node_modules/interface-store": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.8.tgz",
+      "integrity": "sha512-7na81Uxkl0vqk0CBPO5PvyTkdaJBaezwUJGsMOz7riPOq0rJt+7W31iaopaMICWea/iykUsvNlPx/Tc+MxC3/w=="
+    },
     "node_modules/internal-slot": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
@@ -4775,6 +6391,36 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
+      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ipns": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-9.1.2.tgz",
+      "integrity": "sha512-lh/uNTgtHCD737WqJDGGLC9esoUeSnDakdLga8lcy6l+BDSTvdoRkjGXkHSOt+z8WJYeTbna5+nnBYNWt58ZBw==",
+      "dependencies": {
+        "@libp2p/crypto": "^4.0.0",
+        "@libp2p/interface": "^1.1.0",
+        "@libp2p/logger": "^4.0.3",
+        "@libp2p/peer-id": "^4.0.3",
+        "cborg": "^4.0.1",
+        "err-code": "^3.0.1",
+        "interface-datastore": "^8.1.0",
+        "multiformats": "^13.0.0",
+        "protons-runtime": "^5.2.1",
+        "timestamp-nano": "^1.0.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.0.1"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4908,6 +6554,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4965,6 +6616,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-ip": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.1.tgz",
+      "integrity": "sha512-FCsGHdlrOnZQcp0+XT5a+pYowf33itBalCl+7ovNXC/7o5BhIpG14M3OrpPPdBSIQJCm+0M5+9mO7S9VVTTCFw==",
+      "dependencies": {
+        "ip-regex": "^5.0.0",
+        "super-regex": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-loopback-addr": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-loopback-addr/-/is-loopback-addr-2.0.2.tgz",
+      "integrity": "sha512-26POf2KRCno/KTNL5Q0b/9TYnL00xEsSaLfiFRmjM7m7Lw7ZMmFybzzuX4CcsLAluZGd+niLUiMRxEooVE3aqg=="
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -4987,6 +6658,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-network-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.1.0.tgz",
+      "integrity": "sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -5022,6 +6704,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-promise": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
@@ -5042,6 +6732,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regexp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
+      "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-set": {
@@ -5069,6 +6770,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -5165,8 +6877,215 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/it-all": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.6.tgz",
+      "integrity": "sha512-HXZWbxCgQZJfrv5rXvaVeaayXED8nTKx9tj9fpBhmcUJcedVZshMMMqTj0RG2+scGypb9Ut1zd1ifbf3lA8L+Q=="
+    },
+    "node_modules/it-byte-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/it-byte-stream/-/it-byte-stream-1.1.0.tgz",
+      "integrity": "sha512-WWponBWdKEa6o2U3NX+wGMY8X1EkWXcQvpC+3CUqKb4ZzK30q3EPqiTjFxLf9tNVgdF/MNAtx/XclpVfgaz9KQ==",
+      "dependencies": {
+        "it-queueless-pushable": "^1.0.0",
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/it-drain": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-3.0.7.tgz",
+      "integrity": "sha512-vy6S1JKjjHSIFHgBpLpD1zhkCRl3z1zYWUxE14+kAYf+BL9ssWSFImJfhl361IIcwr0ofw8etzg11VqqB+ntUA=="
+    },
+    "node_modules/it-filter": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-3.1.1.tgz",
+      "integrity": "sha512-TOXmVuaSkxlLp2hXKoMTra0WMZMKVFxE3vSsbIA+PbADNCBAHhjJ/lM31vBOUTddHMO34Ku++vU8T9PLlBxQtg==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/it-first": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.6.tgz",
+      "integrity": "sha512-ExIewyK9kXKNAplg2GMeWfgjUcfC1FnUXz/RPfAvIXby+w7U4b3//5Lic0NV03gXT8O/isj5Nmp6KiY0d45pIQ=="
+    },
+    "node_modules/it-foreach": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-2.1.1.tgz",
+      "integrity": "sha512-ID4Gxnavk/LVQLQESAQ9hR6dR63Ih6X+8VdxEktX8rpz2dCGAbZpey/eljTNbMfV2UKXHiu6UsneoNBZuac97g==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/it-length": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/it-length/-/it-length-3.0.6.tgz",
+      "integrity": "sha512-R7bxHAzpRzYz7vghc2DDH7x4KXvEkeLfN/h316++jzbkEHIRXbEPLbE20p5yrqqBdOeK6/FRUDuHlTJ0H1hysw=="
+    },
+    "node_modules/it-length-prefixed": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-9.1.0.tgz",
+      "integrity": "sha512-kx2UTJuy7/lsT3QUzf50NjfxU1Z4P4wlvYp6YnR5Nc61P8XKfy+QtiJi1VLojA+Kea7vMbB4002rIij1Ol9hcw==",
+      "dependencies": {
+        "it-reader": "^6.0.1",
+        "it-stream-types": "^2.0.1",
+        "uint8-varint": "^2.0.1",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-length-prefixed-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed-stream/-/it-length-prefixed-stream-1.2.0.tgz",
+      "integrity": "sha512-vX7dzSl/2UMYYsAr0FQdPNVR5xYEETaeboZ+eXxNBjgARuvxnWA6OedW8lC5/J3ebMTC98JhA3eH76eTijUOsA==",
+      "dependencies": {
+        "it-byte-stream": "^1.0.0",
+        "it-stream-types": "^2.0.1",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/it-map": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-3.1.1.tgz",
+      "integrity": "sha512-9bCSwKD1yN1wCOgJ9UOl+46NQtdatosPWzxxUk2NdTLwRPXLh+L7iwCC9QKsbgM60RQxT/nH8bKMqm3H/o8IHQ==",
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/it-merge": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.5.tgz",
+      "integrity": "sha512-2l7+mPf85pyRF5pqi0dKcA54E5Jm/2FyY5GsOaN51Ta0ipC7YZ3szuAsH8wOoB6eKY4XsU4k2X+mzPmFBMayEA==",
+      "dependencies": {
+        "it-pushable": "^3.2.3"
+      }
+    },
+    "node_modules/it-ndjson": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/it-ndjson/-/it-ndjson-1.0.7.tgz",
+      "integrity": "sha512-V3IskT5RCVtov1u6sC9gkg0uD02qe8yPoVzBZVaRx+YkuMdpFd6opiAwfYovNd/NEbqo9mBN8wJLtw6vD0Xiqg=="
+    },
+    "node_modules/it-pair": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/it-pair/-/it-pair-2.0.6.tgz",
+      "integrity": "sha512-5M0t5RAcYEQYNG5BV7d7cqbdwbCAp5yLdzvkxsZmkuZsLbTdZzah6MQySYfaAQjNDCq6PUnDt0hqBZ4NwMfW6g==",
+      "dependencies": {
+        "it-stream-types": "^2.0.1",
+        "p-defer": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-parallel": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.8.tgz",
+      "integrity": "sha512-URLhs6eG4Hdr4OdvgBBPDzOjBeSSmI+Kqex2rv/aAyYClME26RYHirLVhZsZP5M+ZP6M34iRlXk8Wlqtezuqpg==",
+      "dependencies": {
+        "p-defer": "^4.0.1"
+      }
+    },
+    "node_modules/it-peekable": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.5.tgz",
+      "integrity": "sha512-JWQOGMt6rKiPcY30zUVMR4g6YxkpueTwHVE7CMs/aGqCf4OydM6w+7ZM3PvmO1e0TocjuR4aL8xyZWR46cTqCQ=="
+    },
+    "node_modules/it-pipe": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-3.0.1.tgz",
+      "integrity": "sha512-sIoNrQl1qSRg2seYSBH/3QxWhJFn9PKYvOf/bHdtCBF0bnghey44VyASsWzn5dAx0DCDDABq1hZIuzKmtBZmKA==",
+      "dependencies": {
+        "it-merge": "^3.0.0",
+        "it-pushable": "^3.1.2",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-protobuf-stream": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/it-protobuf-stream/-/it-protobuf-stream-1.1.5.tgz",
+      "integrity": "sha512-H70idW45As3cEbU4uSoZ9IYHUIV3YM69/2mmXYR7gOlPabWjuyNi3/abK11geiiq3la27Sos/mXr68JljjKtEQ==",
+      "dependencies": {
+        "it-length-prefixed-stream": "^1.0.0",
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/it-pushable": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.3.tgz",
+      "integrity": "sha512-gzYnXYK8Y5t5b/BnJUr7glfQLO4U5vyb05gPx/TyTw+4Bv1zM9gFk4YsOrnulWefMewlphCjKkakFvj1y99Tcg==",
+      "dependencies": {
+        "p-defer": "^4.0.0"
+      }
+    },
+    "node_modules/it-queueless-pushable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-queueless-pushable/-/it-queueless-pushable-1.0.0.tgz",
+      "integrity": "sha512-HbcAbcuQj7a9EBxiRCZ+77FxWutgs/pY5ZvEyQnylWPGNFojCLAUwhcZjf5OuEQ9+y+vSa7w1GQBe8xJdmIn5A==",
+      "dependencies": {
+        "p-defer": "^4.0.1",
+        "race-signal": "^1.0.2"
+      }
+    },
+    "node_modules/it-reader": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-6.0.4.tgz",
+      "integrity": "sha512-XCWifEcNFFjjBHtor4Sfaj8rcpt+FkY0L6WdhD578SCDhV4VUm7fCkF3dv5a+fTcfQqvN9BsxBTvWbYO6iCjTg==",
+      "dependencies": {
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-sort": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-3.0.6.tgz",
+      "integrity": "sha512-aNrlZAXB8vWBd42tCpaXGL6CJVJNDW3OLczmdt6g0k/s9Z6evkTdgU2LjwW5SNNeX41sF+C8MjV+OcVf93PsPw==",
+      "dependencies": {
+        "it-all": "^3.0.0"
+      }
+    },
+    "node_modules/it-stream-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.2.tgz",
+      "integrity": "sha512-Rz/DEZ6Byn/r9+/SBCuJhpPATDF9D+dz5pbgSUyBsCDtza6wtNATrz/jz1gDyNanC3XdLboriHnOC925bZRBww=="
+    },
+    "node_modules/it-take": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/it-take/-/it-take-3.0.6.tgz",
+      "integrity": "sha512-uqw3MRzf9to1SOLxaureGa73lK8k8ZB/asOApTAkvrzUqCznGtKNgPFH7uYIWlt4UuWq/hU6I+U4Fm5xpjN8Vg=="
+    },
+    "node_modules/it-ws": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-6.1.5.tgz",
+      "integrity": "sha512-uWjMtpy5HqhSd/LlrlP3fhYrr7rUfJFFMABv0F5d6n13Q+0glhZthwUKpEAVhDrXY95Tb1RB5lLqqef+QbVNaw==",
+      "dependencies": {
+        "@types/ws": "^8.2.2",
+        "event-iterator": "^2.0.0",
+        "it-stream-types": "^2.0.1",
+        "uint8arrays": "^5.0.0",
+        "ws": "^8.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.2",
@@ -5372,6 +7291,166 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libp2p": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-2.0.3.tgz",
+      "integrity": "sha512-WBnsJdariuFVNCswghG3nGsYUf2VnIsQQA3s+sI/j+z86SErpHI+i6XvRD7zrxZwS+WGFruOXRUwOKw7WKsbiw==",
+      "dependencies": {
+        "@libp2p/crypto": "^5.0.2",
+        "@libp2p/interface": "^2.1.0",
+        "@libp2p/interface-internal": "^2.0.2",
+        "@libp2p/logger": "^5.0.2",
+        "@libp2p/multistream-select": "^6.0.2",
+        "@libp2p/peer-collections": "^6.0.2",
+        "@libp2p/peer-id": "^5.0.2",
+        "@libp2p/peer-store": "^11.0.2",
+        "@libp2p/utils": "^6.0.2",
+        "@multiformats/dns": "^1.0.6",
+        "@multiformats/multiaddr": "^12.2.3",
+        "@multiformats/multiaddr-matcher": "^1.2.1",
+        "any-signal": "^4.1.1",
+        "datastore-core": "^10.0.0",
+        "interface-datastore": "^8.3.0",
+        "it-byte-stream": "^1.0.12",
+        "it-merge": "^3.0.5",
+        "it-parallel": "^3.0.7",
+        "merge-options": "^3.0.4",
+        "multiformats": "^13.1.0",
+        "p-defer": "^4.0.1",
+        "p-retry": "^6.2.0",
+        "progress-events": "^1.0.0",
+        "race-event": "^1.3.0",
+        "race-signal": "^1.0.2",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/@libp2p/crypto": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.0.2.tgz",
+      "integrity": "sha512-eThU7WT/axsypyxiuejYs42Si4htgt3IunmhCZ9pSFmtiBNVnRrqij9/yTgMMXH/2NNkq/8Zq4jLm3cZ5XoAqg==",
+      "dependencies": {
+        "@libp2p/interface": "^2.1.0",
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.4.0",
+        "asn1js": "^3.0.5",
+        "multiformats": "^13.1.0",
+        "protons-runtime": "^5.4.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/@libp2p/interface": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.1.0.tgz",
+      "integrity": "sha512-22TD1KMP29xzlzYNH5zpi3E3WvshNC+MeYm1arD7PjLYvQLYKsm+HVaTVweLtqvuEVjMNNB4Q5JLNelM2tELgA==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.2.3",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^13.1.0",
+        "progress-events": "^1.0.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/libp2p/node_modules/@libp2p/interface-internal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-2.0.2.tgz",
+      "integrity": "sha512-7EDwXhFWahOAiN/jYCJ0UZ8FLiA5jGJYT7OTFOPLNisosP3WM9+fmCwBwkAmXmD1BPpx3M6j0Efy4RCsd0YBUQ==",
+      "dependencies": {
+        "@libp2p/interface": "^2.1.0",
+        "@libp2p/peer-collections": "^6.0.2",
+        "@multiformats/multiaddr": "^12.2.3",
+        "progress-events": "^1.0.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/libp2p/node_modules/@libp2p/logger": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-5.0.2.tgz",
+      "integrity": "sha512-sUE/clwUQQDiPxrtwmfVJjz8B1to713XziTvs9WqEdU6AkoOQV7S18aosvUw3+AjuBMpthYst1gewRkWivH7ag==",
+      "dependencies": {
+        "@libp2p/interface": "^2.1.0",
+        "@multiformats/multiaddr": "^12.2.3",
+        "interface-datastore": "^8.3.0",
+        "multiformats": "^13.1.0",
+        "weald": "^1.0.2"
+      }
+    },
+    "node_modules/libp2p/node_modules/@libp2p/peer-collections": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-6.0.2.tgz",
+      "integrity": "sha512-rpjpXWtX355l9Y0cR/LdvEPsnvbkuRXD47/RPI5Sph654LmMUzxtfoohoyReAU+UUFWt881Oq9rQBe8wkwM3UA==",
+      "dependencies": {
+        "@libp2p/interface": "^2.1.0",
+        "@libp2p/peer-id": "^5.0.2",
+        "@libp2p/utils": "^6.0.2",
+        "multiformats": "^13.2.2"
+      }
+    },
+    "node_modules/libp2p/node_modules/@libp2p/peer-id": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-5.0.2.tgz",
+      "integrity": "sha512-e+9yrSOLh3vUIYmjNb1UwNJ/eRFWcZ0XAze4KIBtmAg3i4MHeO6KKiskpGUBv1AmKWLzfhruLQYSXoPOo943gg==",
+      "dependencies": {
+        "@libp2p/crypto": "^5.0.2",
+        "@libp2p/interface": "^2.1.0",
+        "multiformats": "^13.1.0",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/@libp2p/utils": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-6.0.2.tgz",
+      "integrity": "sha512-W+yo41vLulZkj7FoyMNwncSWJBCbRzzQR9IgA9K/wCII9WzSHDZ/lo6yZXCKW64Tft50cXqW8Cb5Vr/TQcWUWA==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.2",
+        "@libp2p/crypto": "^5.0.2",
+        "@libp2p/interface": "^2.1.0",
+        "@libp2p/logger": "^5.0.2",
+        "@multiformats/multiaddr": "^12.2.3",
+        "@multiformats/multiaddr-matcher": "^1.2.1",
+        "@sindresorhus/fnv1a": "^3.1.0",
+        "@types/murmurhash3js-revisited": "^3.0.3",
+        "any-signal": "^4.1.1",
+        "delay": "^6.0.0",
+        "get-iterator": "^2.0.1",
+        "is-loopback-addr": "^2.0.2",
+        "it-foreach": "^2.1.1",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "murmurhash3js-revisited": "^3.0.0",
+        "netmask": "^2.0.2",
+        "p-defer": "^4.0.1",
+        "race-event": "^1.3.0",
+        "race-signal": "^1.0.2",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/datastore-core": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-10.0.2.tgz",
+      "integrity": "sha512-B3WXxI54VxJkpXxnYibiF17si3bLXE1XOjrJB7wM5co9fx2KOEkiePDGiCCEtnapFHTnmAnYCPdA7WZTIpdn/A==",
+      "dependencies": {
+        "@libp2p/logger": "^5.0.1",
+        "interface-datastore": "^8.0.0",
+        "interface-store": "^6.0.0",
+        "it-drain": "^3.0.7",
+        "it-filter": "^3.1.1",
+        "it-map": "^3.1.1",
+        "it-merge": "^3.0.5",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.2.3",
+        "it-sort": "^3.0.6",
+        "it-take": "^3.0.6"
+      }
+    },
+    "node_modules/libp2p/node_modules/interface-store": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-6.0.2.tgz",
+      "integrity": "sha512-KSFCXtBlNoG0hzwNa0RmhHtrdhzexp+S+UY2s0rWTBJyfdEIgn6i6Zl9otVqrcFYbYrneBT7hbmHQ8gE0C3umA=="
+    },
     "node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -5464,6 +7543,22 @@
         "timers-ext": "^0.1.7"
       }
     },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5484,6 +7579,28 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -5508,7 +7625,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5522,6 +7638,11 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
     "node_modules/mock-socket": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
@@ -5530,10 +7651,45 @@
         "node": ">= 8"
       }
     },
+    "node_modules/mortice": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/mortice/-/mortice-3.0.4.tgz",
+      "integrity": "sha512-MUHRCAztSl4v/dAmK8vbYi5u1n9NZtQu4H3FsqS7qgMFQIAFw9lTpHiErd9kJpapqmvEdD1L3dUmiikifAvLsQ==",
+      "dependencies": {
+        "observable-webworkers": "^2.0.1",
+        "p-queue": "^8.0.1",
+        "p-timeout": "^6.0.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/multicast-dns": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "dependencies": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      }
+    },
+    "node_modules/multiformats": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.0.tgz",
+      "integrity": "sha512-CBiqvsufgmpo01VT5ze94O+uc+Pbf6f/sThlvWss0sBZmAOu6GQn5usrYV2sf2mr17FWYc0rO8c/CNe2T90QAA=="
+    },
+    "node_modules/murmurhash3js-revisited": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
+      "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -5563,11 +7719,24 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/next": {
       "version": "14.2.5",
@@ -5664,6 +7833,48 @@
         "node": ">= 10.13"
       }
     },
+    "node_modules/node-abi": {
+      "version": "3.68.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.68.0.tgz",
+      "integrity": "sha512-7vbj10trelExNjFSBm5kTvZXXa7pZyKWx9RCKIyqe6I9Ev3IzGpQoqBP3a+cOdxY+pWj6VkP28n/2wWysBHD/A==",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-datachannel": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.11.0.tgz",
+      "integrity": "sha512-8/vAMms32XxgJ9FIRDXbfmmH1ROm0HBdsa/XteIcUWN4VTQN38UITTkuu6YsfQzN/CQp8YhhnfAEzEadQJ2c6Q==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-domexception": "^2.0.1",
+        "prebuild-install": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/node-datachannel/node_modules/node-domexception": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-2.0.1.tgz",
+      "integrity": "sha512-M85rnSC7WQ7wnfQTARPT4LrK7nwCHLdDFOCcItZMhTQjyCebJH8GciKqYJNgaOFZs9nFmTmd/VMyi3OW5jA47w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -5721,6 +7932,31 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/object-assign": {
@@ -5857,13 +8093,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/observable-webworkers": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/observable-webworkers/-/observable-webworkers-2.0.1.tgz",
+      "integrity": "sha512-JI1vB0u3pZjoQKOK1ROWzp0ygxSi7Yb0iR+7UNsw4/Zn4cQ0P3R7XL38zac/Dy2tEA7Lg88/wIJTjF8vYXZ0uw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -5881,6 +8139,31 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
+      "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-event": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+      "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+      "dependencies": {
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-limit": {
@@ -5908,6 +8191,48 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.0.1.tgz",
+      "integrity": "sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.0.tgz",
+      "integrity": "sha512-JA6nkq6hKyWLLasXQXUrO4z8BUZGUt/LjlJxx8Gb2+2ntodU/SS63YZ8b0LUTbQ8ZB9iwOfhEPhg4ykKnn2KsA==",
+      "dependencies": {
+        "@types/retry": "0.12.2",
+        "is-network-error": "^1.0.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
+      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5947,7 +8272,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6176,6 +8500,31 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+      "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6294,6 +8643,11 @@
         }
       }
     },
+    "node_modules/progress-events": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.0.1.tgz",
+      "integrity": "sha512-MOzLIwhpt64KIVN64h1MwdKWiyKFNc/S6BoYKPIVUHFg0/eIEyBulhWCgn678v/4c0ri3FdGuzXymNCv02MUIw=="
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6313,6 +8667,25 @@
         "node": ">= 8"
       }
     },
+    "node_modules/protons-runtime": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.5.0.tgz",
+      "integrity": "sha512-EsALjF9QsrEk6gbCx3lmfHxVN0ah7nG3cY7GySD4xf4g8cr7g543zB88Foh897Sr1RQJ9yDCUsoT1i1H/cVUFA==",
+      "dependencies": {
+        "uint8-varint": "^2.0.2",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6320,6 +8693,22 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
+      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
+      "dependencies": {
+        "tslib": "^2.6.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/queue-microtask": {
@@ -6341,6 +8730,38 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/race-event": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/race-event/-/race-event-1.3.0.tgz",
+      "integrity": "sha512-kaLm7axfOnahIqD3jQ4l1e471FIFcEGebXEnhxyLscuUzV8C94xVHtWEqDDXxll7+yu/6lW0w1Ff4HbtvHvOHg=="
+    },
+    "node_modules/race-signal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-1.1.0.tgz",
+      "integrity": "sha512-VqsW1uzCXfKBd2DhA3K3NhQlqQr04+5WQ7+kHpf1HzT01Q+ePSFWZdQHXKZPuLmm2eXTZM1XLO76cq15ZRAaEA=="
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -6371,6 +8792,19 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/react-native-webrtc": {
+      "version": "118.0.7",
+      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-118.0.7.tgz",
+      "integrity": "sha512-odgd4CNSGQmI8n/pEbxlUtJBTJ8uqE51B1/NUEAvO1AQbeXsyFNHEG0H2T27eMefo5u0GKcRpNkZpXi6fctTkQ==",
+      "dependencies": {
+        "base64-js": "1.5.1",
+        "debug": "4.3.4",
+        "event-target-shim": "6.0.2"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.60.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -6378,6 +8812,19 @@
       "dev": true,
       "dependencies": {
         "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -6477,6 +8924,14 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -6573,6 +9028,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
@@ -6589,6 +9063,19 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
     },
     "node_modules/scale-ts": {
       "version": "1.6.0",
@@ -6607,7 +9094,6 @@
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
       "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6659,7 +9145,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -6671,7 +9156,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6706,6 +9190,49 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -6732,12 +9259,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stream-to-it": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-1.0.1.tgz",
+      "integrity": "sha512-AqHYAYPHcmvMrcLNgncE/q0Aj/ajP6A4qGhxP6EVn7K3YTNs0bJpJyk57wc2Heb7MUL64jurvmnmui8D9kjZgA==",
+      "dependencies": {
+        "it-stream-types": "^2.0.1"
+      }
+    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -6914,6 +9457,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -6968,6 +9522,22 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/super-regex": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-0.2.0.tgz",
+      "integrity": "sha512-WZzIx3rC1CvbMDloLsVw0lkZVKJWbrkJ0k1ghKFmcnPrW1+jWbgTkTEWVtD9lMdmI4jZEz40+naBxl1dCUhXXw==",
+      "dependencies": {
+        "clone-regexp": "^3.0.0",
+        "function-timeout": "^0.1.0",
+        "time-span": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/supports-color": {
@@ -7045,6 +9615,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -7072,6 +9668,25 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+    },
+    "node_modules/time-span": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+      "dependencies": {
+        "convert-hrtime": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/timers-ext": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
@@ -7085,6 +9700,14 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/timestamp-nano": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.1.tgz",
+      "integrity": "sha512-4oGOVZWTu5sl89PtCDnhQBSt7/vL1zVEwAfxH1p49JhTosxzVQWYBYFRFZ8nJmo0G6f824iyP/44BFAwIoKvIA==",
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7095,6 +9718,14 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7147,6 +9778,17 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type": {
       "version": "2.7.3",
@@ -7264,6 +9906,31 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uint8-varint": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.4.tgz",
+      "integrity": "sha512-FwpTa7ZGA/f/EssWAb5/YV6pHgVF1fViKdW8cWaEarjB8t7NyofSWBdOTyFPaGuUG4gx3v1O3PQ8etsiOs3lcw==",
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/uint8arraylist": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.8.tgz",
+      "integrity": "sha512-vc1PlGOzglLF0eae1M8mLRTBivsvrGsdmJ5RbK3e+QRvRLOZfZhQROTwH/OfyF3+ZVUg9/8hE8bmKP2CvP9quQ==",
+      "dependencies": {
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -7323,11 +9990,43 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA=="
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/weald": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/weald/-/weald-1.0.2.tgz",
+      "integrity": "sha512-iG5cIuBwsPe1ZcoGGd4X6QYlepU1vLr4l4oWpzQWqeJPSo9B8bxxyE6xlnj3TCmThtha7gyVL+uuZgUFkPyfDg==",
+      "dependencies": {
+        "ms": "^3.0.0-canary.1",
+        "supports-color": "^9.4.0"
+      }
+    },
+    "node_modules/weald/node_modules/ms": {
+      "version": "3.0.0-canary.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
+      "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
+      "engines": {
+        "node": ">=12.13"
+      }
+    },
+    "node_modules/weald/node_modules/supports-color": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
+      "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
@@ -7337,11 +10036,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wherearewe": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-2.0.1.tgz",
+      "integrity": "sha512-XUguZbDxCA2wBn2LoFtcEhXL6AXo+hVjGonwhSTTTU9SzbWG8Xu3onNIpzf9j/mYUcJQ0f+m37SzG77G851uFw==",
+      "dependencies": {
+        "is-electron": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -7537,8 +10247,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
       "version": "8.18.0",
@@ -7558,6 +10267,26 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/yaml": {

--- a/src/app/murmurClient.ts
+++ b/src/app/murmurClient.ts
@@ -1,4 +1,6 @@
+import type { IIpfsService } from "@/services/IIpfsService";
 import type { IMurmurService } from "@/services/IMurmurService";
+import { IpfsService } from "@/services/IpfsService";
 import { MurmurService } from "@/services/MurmurService";
 import { container, delay, inject, injectable, registry } from "tsyringe";
 
@@ -7,10 +9,18 @@ import { container, delay, inject, injectable, registry } from "tsyringe";
     {
         token: "MurmurServiceImplementation",
         useToken: delay(() => MurmurService)
+    },
+    {
+        token: "IpfsServiceImplementation",
+        useToken: delay(() => IpfsService)
     }
 ])
 class MurmurClient {
-    constructor(@inject("MurmurServiceImplementation") public service: IMurmurService) { }
+    constructor(@inject("MurmurServiceImplementation") public murmurServiceInstance: IMurmurService,
+    @inject("IpfsServiceImplementation") public ipfsServiceInstance: IIpfsService
+
+) { }
 }
 
-export const murmurClient: IMurmurService = container.resolve(MurmurClient).service;
+export const murmurClient: IMurmurService = container.resolve(MurmurClient).murmurServiceInstance;
+export const ipfsClient: IIpfsService = container.resolve(MurmurClient).ipfsServiceInstance;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,26 @@
 'use client'
 
 import { Heading, Subheading } from '@/components/heading'
-import { container } from "tsyringe";
-import { IpfsService } from '@/services/IpfsService';
-import { Button } from '@headlessui/react';
-import { murmurClient } from './murmurClient';
+import { murmurClient, ipfsClient } from './murmurClient';
 import "reflect-metadata";
+import { Button } from '@/components/button';
 
 export default function Home() {
 
-  const etfApi = container.resolve(IpfsService);
-  console.log("Service instance initialized", murmurClient);
+  console.log(`Service instances murmur: ${murmurClient} and ipfs ${ipfsClient}`);
+
+  async function handleIpfsTest() {
+    const cid = await ipfsClient.writeObject({ hello: 'world' });
+    console.log(`CID: ${cid}`);
+    const object = await ipfsClient.getObject(cid);
+    console.log(`Object: ${object}`);
+  }
 
   return (
     <>
       <Heading>Murmur Wallet</Heading>
       <Subheading>Coming soon! Work in progress...</Subheading>
-      <button onClick={() => etfApi.writeObject({})}> IPFS test</button>
+      <Button color='purple' onClick={() => handleIpfsTest()}> IPFS test</Button>
     </>
   )
 }

--- a/src/services/IIpfsService.ts
+++ b/src/services/IIpfsService.ts
@@ -1,0 +1,4 @@
+export interface IIpfsService {
+    writeObject: (dataObject: any) => Promise<any>;
+    getObject: (cid: any) => Promise<any>;
+}

--- a/src/services/IpfsService.ts
+++ b/src/services/IpfsService.ts
@@ -1,80 +1,71 @@
-import {createHelia} from 'helia';
-import {dagCbor} from '@helia/dag-cbor';
-import {CID} from 'multiformats/cid'
+import { createHelia } from 'helia';
+import { dagCbor } from '@helia/dag-cbor';
 import { singleton } from 'tsyringe';
-import {createLibp2p} from 'libp2p';
-// import { gossipsub } from '@chainsafe/libp2p-gossipsub'
-// import { noise } from '@chainsafe/libp2p-noise'
-// import { yamux } from '@chainsafe/libp2p-yamux'
 import { circuitRelayTransport } from '@libp2p/circuit-relay-v2'
-import { dcutr } from '@libp2p/dcutr'
 import { identify } from '@libp2p/identify'
 import { webTransport } from '@libp2p/webtransport'
 import { webSockets } from '@libp2p/websockets'
 import * as filters from '@libp2p/websockets/filters'
-// import { multiaddr } from '@multiformats/multiaddr'
 import { bootstrap } from '@libp2p/bootstrap';
-import { pubsubPeerDiscovery } from '@libp2p/pubsub-peer-discovery'
 import { webRTC } from '@libp2p/webrtc';
+import { createLibp2p } from 'libp2p';
+import { IIpfsService } from './IIpfsService';
 
 @singleton()
-export class IpfsService {
-    url: any;
-    ipfs: any;
+export class IpfsService implements IIpfsService {
+  url: any;
+  ipfs: any;
 
-    constructor() {
-        this.setupLibp2p().then((libp2p) => {
-          createHelia(libp2p).then(helia => {
-            this.ipfs = dagCbor(helia);
-            console.log("done with ipfs creation");
-          });
-        })
-    }
+  constructor() {
+    this.setupLibp2p().then((libp2p) => {
+      createHelia(libp2p).then(helia => {
+        this.ipfs = dagCbor(helia);
+        console.log("done with ipfs creation");
+      });
+    })
+  }
 
-    async setupLibp2p(): Promise<any> {
+  async setupLibp2p(): Promise<any> {
 
-      const gatewayAddr = '/ip4/3.89.149.30/ipfs/'
+    const gatewayAddr = '/ip4/3.89.149.30/ipfs/'
 
-      await createLibp2p({
-        addresses: {          
-          listen: [
-            '/webrtc'
-        ]},
-        transports: [
-          webSockets({
-            // Allow all WebSocket connections inclusing without TLS
-            filter: filters.all,
-          }),
-          webTransport(),
-          webRTC(),
-          circuitRelayTransport({
-            discoverRelays: 1,
-          }),
-        ],
-        peerDiscovery: [
-          bootstrap({
-            list: [gatewayAddr],
-          }),
-        ],
-        services: {
-          identify: identify(),
-        },   
-      })
-    }
+    await createLibp2p({
+      addresses: {
+        listen: [
+          '/webrtc'
+        ]
+      },
+      transports: [
+        webSockets({
+          // Allow all WebSocket connections inclusing without TLS
+          filter: filters.all,
+        }),
+        webTransport(),
+        webRTC(),
+        circuitRelayTransport({
+          discoverRelays: 1,
+        }),
+      ],
+      peerDiscovery: [
+        bootstrap({
+          list: [gatewayAddr],
+        }),
+      ],
+      services: {
+        identify: identify(),
+      },
+    })
+  }
 
-    async writeObject (dataObject: any): Promise<any> {
+  async writeObject(dataObject: any): Promise<any> {
+    if (!dataObject) throw new Error('Data object is required');
+    const cid = await this.ipfs.add(dataObject);
+    Promise.resolve(cid);
+  }
 
-      const cid = await this.ipfs.add({hello: 'world'});
-      console.log("cid: ")
-      console.log(cid.toString());
-      console.log(cid.toJSON());
-
-      const obj = await this.ipfs.get(cid);
-      console.log(obj);
-
-
-
-    }
-
-    
+  async getObject(cid: any): Promise<any> {
+    if (!cid) throw new Error('CID is required');
+    const obj = await this.ipfs.get(cid);
+    Promise.resolve(obj);
+  }
 }


### PR DESCRIPTION
This PR includes the following changes

1.  IIpfsService interface added
2. IpfsService refactored to implement IIpfsService
3. WriteObject method refactored to be two independent methods (write and get instead), and removed some hardcode.
4. IPFS test in Home component refactored.

Ipfs service instance included as part of murmurClient.ts, example of use below:

`import { ipfsClient } from './murmurClient';`
`const cid = await ipfsClient.writeObject({ hello: 'world' });`
`const object = await ipfsClient.getObject(cid)`
